### PR TITLE
Install from clean slate

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "marius@promethost.com"
 license          "Apache 2.0"
 description      "Installs/Configures drupal"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.0"
+version          "1.1.1"
 recipe           "drupal", "Installs and configures Drupal"
 recipe           "drupal::cron", "Sets up the default drupal cron"
 recipe           "drupal::drush", "Installs drush - a command line shell and scripting interface for Drupal"

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ recipe           "drupal", "Installs and configures Drupal"
 recipe           "drupal::cron", "Sets up the default drupal cron"
 recipe           "drupal::drush", "Installs drush - a command line shell and scripting interface for Drupal"
 
-%w{ php apache2 mysql openssl }.each do |cb|
+%w{ postfix php apache2 mysql openssl }.each do |cb|
   depends cb
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@
 
 include_recipe %w{apache2 apache2::mod_php5 apache2::mod_rewrite apache2::mod_expires}
 include_recipe %w{php php::module_mysql php::module_gd}
+include_recipe "postfix"
 include_recipe "drupal::drush"
 include_recipe "mysql::server"
 

--- a/templates/default/drupal.conf.erb
+++ b/templates/default/drupal.conf.erb
@@ -1,6 +1,6 @@
 <VirtualHost *:80>
   ServerName <%= @params[:server_name] %>
-  ServerAlias <% @params[:server_aliases].each do |a| %><%= "#{a}" %> <% end %>
+  ServerAlias <% [*@params[:server_aliases]].each do |a| %><%= "#{a}" %> <% end %>
   DocumentRoot <%= @params[:docroot] %>
 
   <Directory <%= @params[:docroot] %>>


### PR DESCRIPTION
Drush fails on testing email delivery of `admin@<domain>`. This will install postfix and let the install finish.

It also fixes a bug where a string is passed to `server_alias`, but `.each` is used causing a stack trace.
