### PR TITLE
Add php-dom extension for CentOs platform.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,14 @@ include_recipe %w{php php::module_mysql php::module_gd}
 include_recipe "postfix"
 include_recipe "drupal::drush"
 
+# Centos does not include the php-dom extension in it's minimal php install.
+case node[:platform]
+when "centos"
+  package 'php-dom' do
+    action :install
+  end
+end
+
 if node['drupal']['site']['host'] == "localhost"
   include_recipe "mysql::server"
 else


### PR DESCRIPTION
The build fails on my CentoOs6.3 base box because drush install throws
an Exception when it does not find the php-dom extension.

The minimum PHP package on CentOs does not include the php-dom extension by default.

Note there is no php:module_dom recipe to add via the requirement stament.  Also, the
maintainer of the php cookbook has depricated all the module_<extension>
recipes, and is asking developers that require these extensions to include them via a call to package as I do here.
