### PR TITLE
Require cron recipe in default recipe.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ recipe           "drupal", "Installs and configures Drupal"
 recipe           "drupal::cron", "Sets up the default drupal cron"
 recipe           "drupal::drush", "Installs drush - a command line shell and scripting interface for Drupal"
 
-%w{ postfix php apache2 mysql openssl firewall }.each do |cb|
+%w{ postfix php apache2 mysql openssl firewall cron }.each do |cb|
   depends cb
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,7 @@
 include_recipe %w{apache2 apache2::mod_php5 apache2::mod_rewrite apache2::mod_expires}
 include_recipe %w{php php::module_mysql php::module_gd}
 include_recipe "postfix"
+include_recipe "cron"
 include_recipe "drupal::drush"
 
 if node['drupal']['site']['host'] == "localhost"


### PR DESCRIPTION
Some small CentOs installations do not come with cron by default. This
change helps ensure that a build does not fail because crontab is not
available.
