### PR TITLE
Check for a default site before disabling it.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -108,4 +108,5 @@ include_recipe "drupal::cron"
 execute "disable-default-site" do
    command "sudo a2dissite default"
    notifies :reload, "service[apache2]", :delayed
+   only_if do File.exists? "#{node['apache']['dir']}/sites-enabled/default" end
 end


### PR DESCRIPTION
The build fails on our centos63 platform because the default site is not
enabled and the `a2dissite` command throws an error when it does not find it.
This commit corrects this issue by making sure this command is only invoked
when a default site is present.

Note that in the current apache2 cookbook `default['apache']['default_site_enabled']`
is set to `false` for all platforms.

The following is the error thrown on failure prior to this patch:

```
[2013-02-13T04:39:14+00:00] ERROR: Running exception handlers
[2013-02-13T04:39:14+00:00] ERROR: Exception handlers complete
Chef Client failed. 117 resources updated?[0m
[2013-02-13T04:39:14+00:00] FATAL: Stacktrace dumped to /tmp/chef-solo/chef-
stacktrace.out
[2013-02-13T04:39:14+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed:
execute[disable-default-site] (drupal::default line 108) had an error: Mixlib:: ShellOut::ShellCommandFailed: Expected
 process to exit with [0], but received '1'
---- Begin output of sudo a2dissite default ----
STDOUT: This site is already disabled, or does not exist!
STDERR:
---- End output of sudo a2dissite default ----
Ran sudo a2dissite default returned 1
ERROR: RuntimeError: chef-solo failed. See output above.
```
