### PR TITLE
Add iptables configuration for CentOs.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,12 +8,12 @@ version          "1.1.1"
 recipe           "drupal", "Installs and configures Drupal"
 recipe           "drupal::cron", "Sets up the default drupal cron"
 recipe           "drupal::drush", "Installs drush - a command line shell and scripting interface for Drupal"
-
-%w{ postfix php apache2 mysql openssl firewall cron }.each do |cb|
+recipe           "drupal:iptables", "Handles opening up the HTTP ports for CentOs VMs."
+%w{ postfix php apache2 mysql openssl firewall iptables cron }.each do |cb|
   depends cb
 end
 
-%w{ debian ubuntu }.each do |os|
+%w{ debian ubuntu centos}.each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,6 +29,8 @@ when 'rhel', 'fedora'
   package 'php-dom' do
     action :install
   end
+  # CentOs closes port 80, 443 by default.
+  include_recipe "drupal::iptables"
 end
 
 if node['drupal']['site']['host'] == "localhost"

--- a/recipes/iptables.rb
+++ b/recipes/iptables.rb
@@ -1,0 +1,6 @@
+include_recipe "iptables"
+
+iptables_rule "all_established"
+iptables_rule "ssh"
+iptables_rule "http"
+

--- a/templates/default/all_established.erb
+++ b/templates/default/all_established.erb
@@ -1,0 +1,2 @@
+# Any established connection is money
+-A FWR -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/templates/default/http.erb
+++ b/templates/default/http.erb
@@ -1,0 +1,6 @@
+# Port 80 for http
+-A FWR -p tcp -m tcp --dport 80 -j ACCEPT
+
+# Port 443 for http
+-A FWR -p tcp -m tcp --dport 443 -j ACCEPT
+

--- a/templates/default/ssh.erb
+++ b/templates/default/ssh.erb
@@ -1,0 +1,2 @@
+# Port 22 for ssh
+-A FWR -p tcp -m tcp --dport 22 -j ACCEPT


### PR DESCRIPTION
The CentOS VM firewall is very restrictive out of the box. This commit
uses iptables to reconfigure the firewall so that ports 80, 443, and 22
are open for business.  This is the last step needed to make CentOs
boxes work with the drupal-cookbook.

With regard to the firewall recipe that comes with this cookbook:
Unfortunately it does not work for CentOS because CentOS useses iptables
for the firewall.  The README for the iptables cookbook mentions that
there was an effort to merge iptables into the firewall cookbook as an LWRP.
However, as of the time of this commit nothing has come of that effort.
