### PR TITLE
Remove postfix dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Opscode cookbooks (http://github.com/opscode/cookbooks/tree/master)
 * php
 * apache2
 * openssl (used to generate the secure random drupal db password)
-* postfix
 
 # ATTRIBUTES:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-default['drupal']['version'] = "7.18"
+default['drupal']['version'] = "7.21"
 default['drupal']['dir'] = "/var/www/drupal"
 default['drupal']['db']['database'] = "drupal"
 default['drupal']['db']['user'] = "drupal"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ recipe           "drupal", "Installs and configures Drupal"
 recipe           "drupal::cron", "Sets up the default drupal cron"
 recipe           "drupal::drush", "Installs drush - a command line shell and scripting interface for Drupal"
 
-%w{ postfix php apache2 mysql openssl firewall cron }.each do |cb|
+%w{ php apache2 mysql openssl firewall cron }.each do |cb|
   depends cb
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,6 @@
 
 include_recipe %w{apache2 apache2::mod_php5 apache2::mod_rewrite apache2::mod_expires}
 include_recipe %w{php php::module_mysql php::module_gd}
-include_recipe "postfix"
 include_recipe "drupal::drush"
 
 # Centos does not include the php-dom extension in it's minimal php install.


### PR DESCRIPTION
The postfix dependency was introduced because Drupal try to send an email with the password to the site admin.

With version 7.21 it seems it don't do this anymore, so we can remove this dependency.
