### PR TITLE
Create drupal directory if missing

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,9 +8,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,6 +60,12 @@ end
 execute "create #{node['drupal']['db']['database']} database" do
   command "/usr/bin/mysqladmin -h #{node['drupal']['db']['host']} -u root -p#{node['mysql']['server_root_password']} create #{node['drupal']['db']['database']}"
   not_if "mysql -h #{node['drupal']['db']['host']} -u root -p#{node['mysql']['server_root_password']} --silent --skip-column-names --execute=\"show databases like '#{node['drupal']['db']['database']}'\" | grep #{node['drupal']['db']['database']}"
+end
+
+directory node['drupal']['dir'] do
+  recursive true
+  mode '0755'
+  action :create
 end
 
 execute "download-and-install-drupal" do


### PR DESCRIPTION
This is just a small PR to create `node['drupal']['dir']` in case the path does not already exist.  The run will fail if the path does not exist.
